### PR TITLE
Fix file lookup to handle files with numbers in the name

### DIFF
--- a/lib/datafix.rb
+++ b/lib/datafix.rb
@@ -83,7 +83,7 @@ class Datafix
   def fetch_version
     migrations = ActiveRecord::Migrator.migrations(Rails.root.join("db", "datafixes"))
     migrations.detect do |migration|
-      migration.basename.include? script_name.underscore
+      migration.name == script_name
     end.try(:version)
   end
 

--- a/spec/datafixes/3_fix_5_things.rb
+++ b/spec/datafixes/3_fix_5_things.rb
@@ -1,0 +1,7 @@
+class Datafixes::Fix5Things < Datafix
+  def self.up
+  end
+
+  def self.down
+  end
+end

--- a/spec/lib/datafix_spec.rb
+++ b/spec/lib/datafix_spec.rb
@@ -21,6 +21,12 @@ describe Datafix do
       context 'when there is a a file with the script name' do
         it { should == 1 }
       end
+
+      context 'when the datafix name contains a number' do
+        let(:datafix) { Datafixes::Fix5Things.new }
+
+        it { should == 3 }
+      end
     end
 
     describe '#script_name' do


### PR DESCRIPTION
This fixes a bug where datafix names that include numbers were not getting logged to `datafix_statuses`. This is due to a mismatch between the file name having underscores around the number and `.underscore` only putting an underscore after the number. Using the class name instead of the filename should avoid this issue.